### PR TITLE
fix: force alfy version >0.9.0 for Alfred 4 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "alfy"
   ],
   "dependencies": {
-    "alfy": ">0.9.0"
+    "alfy": "^0.9.1"
   },
   "devDependencies": {
     "alfy-test": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "alfy"
   ],
   "dependencies": {
-    "alfy": "^0.9.0"
+    "alfy": ">0.9.0"
   },
   "devDependencies": {
     "alfy-test": "^0.3.0",


### PR DESCRIPTION
Using `alfy ^0.9.0` includes everything greater than 0.9.0 in the same major range, [but includes](https://semver.npmjs.com/) 0.9.0. So the package manager can decide to use 0.9.0 instead of 0.9.1.

Which leads to sometimes having Alfred 4 compatibility and sometimes not having it.

I don't really know how Alfred workflows work, and how you version your software. So I didn't bump the npm version of alfred-kaomoji nor it's info.plist. Let me know if I should do this.